### PR TITLE
Add Z80Assembler class

### DIFF
--- a/Sixty502DotNet.Tests/Z80AssemblerTests.cs
+++ b/Sixty502DotNet.Tests/Z80AssemblerTests.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sixty502DotNet.Tests
+{
+    [TestClass]
+    public class Z80AssemblerTests
+    {
+        [TestMethod]
+        public void Test()
+        {
+            var sut = new Z80Assembler();
+            var input = ";\r\n;\r\nCALL    MAIN \r\n            HALT     \r\nMAIN:                \r\n            LD      a,1 \r\n            LD      b,2 \r\n            ADD     a,b \r\n            RET      \r\n";
+            var bytes = sut.Assemble(input);
+        }
+    }
+}

--- a/Sixty502DotNet.sln
+++ b/Sixty502DotNet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29102.190
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32922.545
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{65F3CE0A-FDA5-438D-A105-AF3DE28915F5}"
 	ProjectSection(SolutionItems) = preProject
@@ -10,9 +10,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sixty502DotNet", "Sixty502DotNet\Sixty502DotNet.csproj", "{509AB312-9232-4063-B964-1E45DCDFCEDE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sixty502DotNet", "Sixty502DotNet\Sixty502DotNet.csproj", "{509AB312-9232-4063-B964-1E45DCDFCEDE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sixty502DotNet.Tests", "Sixty502DotNet.Tests\Sixty502DotNet.Tests.csproj", "{5BFBE0FC-D784-4D6F-91CA-FC6E1FF4FB2A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sixty502DotNet.Tests", "Sixty502DotNet.Tests\Sixty502DotNet.Tests.csproj", "{5BFBE0FC-D784-4D6F-91CA-FC6E1FF4FB2A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,10 +31,6 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{509AB312-9232-4063-B964-1E45DCDFCEDE} = {65F3CE0A-FDA5-438D-A105-AF3DE28915F5}
-		{5BFBE0FC-D784-4D6F-91CA-FC6E1FF4FB2A} = {65F3CE0A-FDA5-438D-A105-AF3DE28915F5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9BE7575F-6E99-4243-AEAA-4D1E1064DA97}

--- a/Sixty502DotNet/Sixty502DotNet.csproj
+++ b/Sixty502DotNet/Sixty502DotNet.csproj
@@ -64,6 +64,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="CSharpFunctionalExtensions" Version="2.35.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.11.1" />
     <PackageReference Include="Antlr4BuildTasks" Version="11.5.0">

--- a/Sixty502DotNet/src/AssemblyData.cs
+++ b/Sixty502DotNet/src/AssemblyData.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using Sixty502DotNet.Runtime;
+
+namespace Sixty502DotNet;
+
+public class AssemblyData
+{
+    public byte[] ProgramBinary { get; }
+    public IEnumerable<DebugEntry> DebugInfo { get; }
+
+    public AssemblyData(byte[] programBinary, IEnumerable<DebugEntry> debugInfo)
+    {
+        ProgramBinary = programBinary;
+        DebugInfo = debugInfo;
+    }
+}

--- a/Sixty502DotNet/src/Runtime/AssemblyServices.cs
+++ b/Sixty502DotNet/src/Runtime/AssemblyServices.cs
@@ -7,107 +7,109 @@
 
 using System;
 using System.Collections.Generic;
+using Sixty502DotNet.Runtime;
 
-namespace Sixty502DotNet
+namespace Sixty502DotNet;
+
+/// <summary>
+/// A service for all shared assembly resources and state, such as
+/// <see cref="ErrorLog"/>, <see cref="CodeOutput"/> , and
+/// <see cref="SymbolManager"/> support classes.
+/// </summary>
+public class AssemblyServices
 {
     /// <summary>
-    /// A service for all shared assembly resources and state, such as
-    /// <see cref="ErrorLog"/>, <see cref="CodeOutput"/> , and
-    /// <see cref="SymbolManager"/> support classes.
+    /// Construct a new instance of the <see cref="AssemblyServices"/>
+    /// class.
     /// </summary>
-    public class AssemblyServices
+    /// <param name="options">The parsed command-line options.</param>
+    public AssemblyServices(Options options)
     {
-        /// <summary>
-        /// Construct a new instance of the <see cref="AssemblyServices"/>
-        /// class.
-        /// </summary>
-        /// <param name="options">The parsed command-line options.</param>
-        public AssemblyServices(Options options)
-        {
-            Options = options;
-            Encoding = new AsmEncoding();
-            Output = new CodeOutput();
-            Log = new ErrorLog(Options.WarningsAsErrors);
-            Symbols = new SymbolManager(Options.CaseSensitive);
-            BuiltInSymbols.Define(this);
-            ExpressionVisitor = new ExpressionVisitor(this);
-            StatementListings = new List<string>();
-            LabelListing = new LabelListing();
-            CPU = OutputFormat = string.Empty;
-            State = new AssemblyState();
-        }
-
-        /// <summary>
-        /// The <see cref="ErrorLog"/> object used for all error and warning
-        /// logging.
-        /// </summary>
-        public ErrorLog Log { get; }
-
-        /// <summary>
-        /// The <see cref="AsmEncoding"/> responsible for all encoding.
-        /// </summary>
-        public AsmEncoding Encoding { get; init; }
-
-        /// <summary>
-        /// The <see cref="ExpressionVisitor"/> responsible for visitng 
-        /// expression parse trees and returning a resulting <see cref="IValue"/>.
-        /// </summary>
-        public ExpressionVisitor ExpressionVisitor { get; init; }
-
-        /// <summary>
-        /// The <see cref="CodeOutput"/> object managing all output of assembly.
-        /// </summary
-        public CodeOutput Output { get; init; }
-
-        /// <summary>
-        /// Gets the output format name.
-        /// </summary>
-        public string OutputFormat { get; private set; }
-
-        /// <summary>
-        /// Gets or sets the CPU.
-        /// </summary>
-        public string CPU { get; set; }
-
-        /// <summary>
-        /// Gets the <see cref="SymbolManager"/> responsible for tracking all
-        /// defined symbols.
-        /// </summary>
-        public SymbolManager Symbols { get; init; }
-
-        /// <summary>
-        /// Get the current assembly state.
-        /// </summary>
-        public AssemblyState State { get; init; }
-
-        /// <summary>
-        /// The <see cref="Sixty502DotNet.Options"/> object responsible for parsing
-        /// and enumerating all command line options.
-        /// </summary>
-        public Options Options { get; }
-
-        /// <summary>
-        /// Get the statement listings as a list of strings.
-        /// </summary>
-        public List<string> StatementListings { get; init; }
-
-        /// <summary>
-        /// Get the <see cref="LabelListing"/> object.
-        /// </summary>
-        public LabelListing LabelListing { get; init; }
-
-        /// <summary>
-        /// Gets the <see cref="System.StringComparer"/> on the case-sensitive
-        /// flag of the set <see cref="Sixty502DotNet.Options"/>.
-        /// </summary>
-        public StringComparer StringComparer
-            => Options.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
-
-        /// <summary>
-        /// Gets the <see cref="System.StringComparison"/> on the case-sensitive
-        /// flag of the set <see cref="Sixty502DotNet.Options"/>.
-        /// </summary>
-        public StringComparison StringComparison
-            => Options.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+        Options = options;
+        Encoding = new AsmEncoding();
+        Output = new CodeOutput();
+        Log = new ErrorLog(Options.WarningsAsErrors);
+        Symbols = new SymbolManager(Options.CaseSensitive);
+        BuiltInSymbols.Define(this);
+        ExpressionVisitor = new ExpressionVisitor(this);
+        StatementListings = new List<string>();
+        LabelListing = new LabelListing();
+        CPU = OutputFormat = string.Empty;
+        State = new AssemblyState();
     }
+
+    /// <summary>
+    /// The <see cref="ErrorLog"/> object used for all error and warning
+    /// logging.
+    /// </summary>
+    public ErrorLog Log { get; }
+
+    /// <summary>
+    /// The <see cref="AsmEncoding"/> responsible for all encoding.
+    /// </summary>
+    public AsmEncoding Encoding { get; init; }
+
+    /// <summary>
+    /// The <see cref="ExpressionVisitor"/> responsible for visitng 
+    /// expression parse trees and returning a resulting <see cref="IValue"/>.
+    /// </summary>
+    public ExpressionVisitor ExpressionVisitor { get; init; }
+
+    /// <summary>
+    /// The <see cref="CodeOutput"/> object managing all output of assembly.
+    /// </summary
+    public CodeOutput Output { get; init; }
+
+    /// <summary>
+    /// Gets the output format name.
+    /// </summary>
+    public string OutputFormat { get; private set; }
+
+    /// <summary>
+    /// Gets or sets the CPU.
+    /// </summary>
+    public string CPU { get; set; }
+
+    /// <summary>
+    /// Gets the <see cref="SymbolManager"/> responsible for tracking all
+    /// defined symbols.
+    /// </summary>
+    public SymbolManager Symbols { get; init; }
+
+    /// <summary>
+    /// Get the current assembly state.
+    /// </summary>
+    public AssemblyState State { get; init; }
+
+    /// <summary>
+    /// The <see cref="Sixty502DotNet.Options"/> object responsible for parsing
+    /// and enumerating all command line options.
+    /// </summary>
+    public Options Options { get; }
+
+    /// <summary>
+    ///     Get the statement listings as a list of strings.
+    /// </summary>
+    public List<string> StatementListings { get; init; }
+
+    /// <summary>
+    /// Get the <see cref="LabelListing"/> object.
+    /// </summary>
+    public LabelListing LabelListing { get; init; }
+
+    /// <summary>
+    /// Gets the <see cref="System.StringComparer"/> on the case-sensitive
+    /// flag of the set <see cref="Sixty502DotNet.Options"/>.
+    /// </summary>
+    public StringComparer StringComparer
+        => Options.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+
+    /// <summary>
+    /// Gets the <see cref="System.StringComparison"/> on the case-sensitive
+    /// flag of the set <see cref="Sixty502DotNet.Options"/>.
+    /// </summary>
+    public StringComparison StringComparison
+        => Options.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+
+    public List<DebugEntry> DebugInfo = new();
 }

--- a/Sixty502DotNet/src/Runtime/DebugEntry.cs
+++ b/Sixty502DotNet/src/Runtime/DebugEntry.cs
@@ -1,0 +1,3 @@
+﻿namespace Sixty502DotNet.Runtime;
+
+public record DebugEntry(int Line, int ProgramCounter, string LineText);

--- a/Sixty502DotNet/src/Z80Assembler.cs
+++ b/Sixty502DotNet/src/Z80Assembler.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Linq;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Atn;
+using Antlr4.Runtime.Tree;
+using CSharpFunctionalExtensions;
+
+namespace Sixty502DotNet;
+
+public class Z80Assembler
+{
+    private CodeGenVisitor _codeGenVisitor;
+    private readonly AssemblyServices _services = new(Options.FromArgs(new[] { "-c", "z80" }));
+
+    public Result<byte[]> Assemble(string input)
+    {
+        var parsedSource = ParseSource(input);
+        if (_services.Log.HasErrors)
+        {
+            _services.Log.DumpErrors(_services.Options.NoHighlighting);
+            return Result.Failure<byte[]>(_services.Log.ToString());
+        }
+
+        var passNeeded = true;
+        while (passNeeded && !_services.Log.HasErrors)
+        {
+            if (_services.State.CurrentPass > 4)
+            {
+                _services.Log.LogEntrySimple("Too many passes attempted.");
+                break;
+            }
+
+            DoPass(parsedSource!);
+            _services.State.CurrentPass++;
+            passNeeded = _services.State.PassNeeded;
+        }
+
+        return _services.Output.GetCompilation().ToArray();
+    }
+
+    private void DoPass(IParseTree parse)
+    {
+        var currentPassVar = _services.Symbols.GlobalScope.Resolve("CURRENT_PASS") as Constant;
+        currentPassVar!.Value.SetAs(new Value(_services.State.CurrentPass + 1));
+        _codeGenVisitor.Reset();
+        _services.Output.Reset();
+        _services.StatementListings.Clear();
+        _services.LabelListing.Clear();
+        _services.Symbols.Reset();
+        _services.State.PassNeeded = false;
+        _ = _codeGenVisitor?.Visit(parse);
+    }
+
+    private Sixty502DotNetParser.SourceContext? ParseSource(string input)
+    {
+        try
+        {
+            var preprocessor = new Preprocessor(_services, CharStreams.fromString(input));
+            var lexer = preprocessor.Lexer;
+            if (lexer == null)
+            {
+                // this could happen if the source input file was not found.
+                return null;
+            }
+
+            var stream = new CommonTokenStream(lexer);
+
+            _codeGenVisitor = new CodeGenVisitor(_services, lexer.InstructionSet!);
+
+            var tokens = stream.GetTokens();
+            var errorTokens = tokens.Where(t => t.Channel == Sixty502DotNetLexer.ERROR).ToList();
+            for (var i = 0; i < errorTokens.Count; ++i)
+            {
+                _services.Log.LogEntry((Token)errorTokens[i], Errors.UnexpectedExpression);
+            }
+
+            if (!_services.Log.HasErrors)
+            {
+                stream.Reset();
+                var parser = new Sixty502DotNetParser(stream)
+                {
+                    Symbols = _services.Symbols
+                };
+                parser.Interpreter.PredictionMode = PredictionMode.SLL;
+                parser.RemoveErrorListeners();
+                parser.AddErrorListener(_services.Log);
+                var parse = parser.source();
+                // parse tree first before constructing code gen visitor to ensure the lexer's
+                // instruction set will be initialized to the correct one (this happens during lexical phase).
+                _codeGenVisitor = new CodeGenVisitor(_services, lexer.InstructionSet!);
+                if (_services.Options.WarnLeft)
+                {
+                    foreach (var label in parser.LabelsAfterWhitespace)
+                    {
+                        _services.Log.LogEntry((Token)label, "Whitespace precedes label.", false);
+                    }
+                }
+
+                return parse;
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _services.Log.LogEntrySimple(ex.Message);
+            return null;
+        }
+    }
+}

--- a/Sixty502DotNet/src/Z80Assembler.cs
+++ b/Sixty502DotNet/src/Z80Assembler.cs
@@ -10,15 +10,15 @@ namespace Sixty502DotNet;
 public class Z80Assembler
 {
     private CodeGenVisitor _codeGenVisitor;
-    private readonly AssemblyServices _services = new(Options.FromArgs(new[] { "-c", "z80" }));
+    private readonly AssemblyServices _services = new(Options.FromArgs(new[] { "-c", "z80", "--list", "fake.s" }));
 
-    public Result<byte[]> Assemble(string input)
+    public Result<AssemblyData> Assemble(string input)
     {
         var parsedSource = ParseSource(input);
         if (_services.Log.HasErrors)
         {
             _services.Log.DumpErrors(_services.Options.NoHighlighting);
-            return Result.Failure<byte[]>(_services.Log.ToString());
+            return Result.Failure<AssemblyData>(_services.Log.ToString());
         }
 
         var passNeeded = true;
@@ -35,7 +35,8 @@ public class Z80Assembler
             passNeeded = _services.State.PassNeeded;
         }
 
-        return _services.Output.GetCompilation().ToArray();
+        var debugInfo = _services.DebugInfo.Distinct().OrderBy(x => x.Line);
+        return new AssemblyData(_services.Output.GetCompilation().ToArray(), debugInfo);
     }
 
     private void DoPass(IParseTree parse)


### PR DESCRIPTION
This PR makes it easier for consumers of this library to use it without relying on the command line part.

Usage:

```
var assembler = new Z80Assembler();
var result = assembler.Assemble(assemblyCode);
if (result.Success) 
{
   byte[] binaryFormat = result.Value;
}
```